### PR TITLE
Added basic status update message

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -150,7 +150,13 @@ export class Events {
   }
 
   static status(data) {
-    return null;
+    const repo = data.repository.full_name;
+    const description = data.description;
+    const state = data.state;
+    const url = data.target_url;
+    const branch = data.branches.length > 0 ? data.branches[0].name : null;
+    const commitMsg = data.commit.message;
+    return `[**${repo}**] ${description}\n${branch}: ${commitMsg}\nState: ${state} ${url}`;
   }
 
   static team_add(data) {


### PR DESCRIPTION
Using the description, state, branch, commit message and target url.

I wanted this so that the bot would know what to do with Semaphore CI updates - this should cover my use case and I hope I've made it general enough so that the output makes sense regardless of what the status update contains (even if some of the properties I am using are null).