### PR TITLE
Accept private repos when using the --private flag

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -7,23 +7,31 @@ export default class Commands {
    * Check if the repo is public or private.
    */
   static add(channel, repo, _private) {
-    request(`https://github.com/${repo}`, (err, res) => {
-      if (res.statusCode === 200) {
-        return Actions.add(repo, channel.id)
-        .then(result => channel.sendMessage(result))
-        .catch(error => {
-          console.error('ERROR:', error);
-          channel.sendMessage('Something went wrong. An error has been logged.')
-        });
-      }
-      if (res.statusCode === 404) {
-        if (_private === '--private') {
-          // Check if the user has a token stored.
-        } else {
+
+    if (_private === '--private') {
+      // If the repo is private it will always return 404
+      // So lets add it in good faith anyway.
+      return Actions.add(repo, channel.id)
+      .then(result => channel.sendMessage(result))
+      .catch(error => {
+        console.error('ERROR:', error);
+        channel.sendMessage('Something went wrong. An error has been logged.')
+      });
+    } else {
+      request(`https://github.com/${repo}`, (err, res) => {
+        if (res.statusCode === 200) {
+          return Actions.add(repo, channel.id)
+          .then(result => channel.sendMessage(result))
+          .catch(error => {
+            console.error('ERROR:', error);
+            channel.sendMessage('Something went wrong. An error has been logged.')
+          });
+        }
+        if (res.statusCode === 404) {
           channel.sendMessage('Repository not found.');
         }
-      }
-    });
+      });
+    }
   }
 
   static remove(channel, repo, _private) {


### PR DESCRIPTION
At the moment there is no way to add a private repo because the current existence check that calls github.com/org/repo will always return 404 unless called by a logged in user with access to repo that is being requested.

I therefore propose that when using the --private flag the bot will accept the repo in good faith until a better solution can be found.

#34 #38 