### PR TITLE
Added discord markdown for disabling URLs previews

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -53,7 +53,7 @@ export default class Events {
     const body = data.comment.body;
     const title = data.issue.title;
     let message = `[**${repo}**] Comment created on issue: ${title} by ${user}`;
-    message += `\n${url}`;
+    message += `\n<${url}>}`;
     message += `\n${body}`;
     return message;
   }
@@ -63,14 +63,14 @@ export default class Events {
     const action = data.action;
     const user = data.sender.login;
     const url = data.issue.html_url;
-    return `[**${repo}**] Issue ${action} by ${user}\n${url}`;
+    return `[**${repo}**] Issue ${action} by ${user}\n<${url}>}`;
   }
 
   static member(data) {
     const repo = data.repository.full_name;
     const user = data.member.login;
     const url = data.member.html_url;
-    return `[**${repo}**] New collaborator added: ${user}\n${url}`;
+    return `[**${repo}**] New collaborator added: ${user}\n<${url}>}`;
   }
 
   static membership(data) {
@@ -94,7 +94,7 @@ export default class Events {
     const url = data.comment.html_url;
     let message = `[**${repo}**] Pull Request comment ${action} by ${user}:`;
     message += `\n${body}`;
-    message += `\n${url}`;
+    message += `\n<${url}>}`;
     return message;
   }
 
@@ -106,7 +106,7 @@ export default class Events {
     const url = data.pull_request.html_url;
     let message = `[**${repo}**] Pull Request ${action} by ${user}:`;
     message += `\n${body}`;
-    message += `\n${url}`;
+    message += `\n<${url}>}`;
     return message;
   }
 
@@ -122,7 +122,7 @@ export default class Events {
       const url = `https://github.com/${repo}/commit/${sha}`;
       message += `[**${repo}:${branch}**] 1 new commit by ${name}`;
       message += `\n${commitMessage} - ${name}`;
-      message += `\n${url}`;
+      message += `\n<${url}>}`;
     } else {
       const commits = data.commits;
 
@@ -132,7 +132,7 @@ export default class Events {
         const sha = commit.id.substring(0, 7);
         const url = `https://github.com/${repo}/commit/${sha}`;
         message += `\n${commit.message} - ${commit.author.name}`;
-        message += `\n${url}`;
+        message += `\n<${url}>}`;
       }
     }
     return message;
@@ -146,7 +146,7 @@ export default class Events {
     const repo = data.repository.full_name;
     const user = data.release.author.login;
     const url = data.release.html_url;
-    return `[**${repo}**] Release published by ${user}:\n${url}`;
+    return `[**${repo}**] Release published by ${user}:\n<${url}>}`;
   }
 
   static status(data) {
@@ -156,7 +156,7 @@ export default class Events {
     const url = data.target_url;
     const branch = data.branches.length > 0 ? data.branches[0].name : null;
     const commitMsg = data.commit.message;
-    return `[**${repo}**] ${description}\n${branch}: ${commitMsg}\nState: ${state} ${url}`;
+    return `[**${repo}**] ${description}\n${branch}: ${commitMsg}\nState: ${state} <${url}>}`;
   }
 
   static team_add(data) {


### PR DESCRIPTION
This PR inserts Discord markdown chars `<` & `>` to generated messages, to prevent previews display in the channel.

Closes #39 