### PR TITLE
Node engine increment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build && node build/bundle.js"
   },
   "engines": {
-    "node": "14.15.1"
+    "node": ">14.15.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since Node's stable LTS is now the 14.16.0 version - only seen on MacOSX, the package.json engine should allow higher version than 14.15.0 as it is an old version