### PR TITLE
Correct the security vulnerability language

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can specify a secret value when subscribing to receive webhook events. Keep 
 
 Don't just enter your "default password" as the secret, use some random value, unrelated text, or best of all: [a hashed value](https://emn178.github.io/online-tools/sha256.html).
 
-> If anyone guesses your secret, they can also subscribe to your webhook events!
+> If anyone learns or guesses your secret, they can send fake webhook events!
 
 ## Usage
 


### PR DESCRIPTION
The secret is used to sign the webhook so you can verify the signature to ensure you know the webhook came from GitHub. If an attacker were to learn or guess the secret, they would be able to create fake events and sign them with the same secret, so you would think they came from GitHub. They would not, however, get access to receive your webhooks.